### PR TITLE
Conditional rendering on authorize check

### DIFF
--- a/src/components/AuthRender.js
+++ b/src/components/AuthRender.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { useAuth } from "../contexts/AuthContext";
+// How to use this component:
+// props.dontRender = false (default)
+// if Authed        : Render
+// if Not Authed    : Dont Render
+
+// props.dontRender = true
+// if Authed        : Dont Render
+// If Not Authed    : Render
+
+export default function AuthRender(props) {
+  const { currentUser } = useAuth();
+
+  return <>{currentUser && props.children}</>;
+}

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios";
+// import axios from "axios";
 import { useAuth } from "../contexts/AuthContext";
 import { Link, useHistory } from "react-router-dom";
 import { GiCoffeeBeans } from "react-icons/gi";
-import Popup from "./Popup";
 
 import { toast } from "react-toastify";
 import AnimatedLoadingIcon from "./AnimatedLoadingIcon";
@@ -14,7 +13,7 @@ const LoginForm = () => {
     email: "",
     password: "",
   });
-  const { login, currentUser } = useAuth();
+  const { login, currentUser, authStateChecked } = useAuth();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const handleChange = (event, fieldName) => {
@@ -46,52 +45,56 @@ const LoginForm = () => {
 
   return (
     <div class="md:mt-20 p-2 md:max-w-6xl md:p-12 mx-auto">
-      <div className="grid grid-cols-1 md:grid-cols-2 md:h-96 border border-gray-300 rounded-2xl shadow-xl overflow-hidden">
-        <form className="w-full p-12 col-span-1 flex flex-col justify-center flex-shrink-0">
-          <h2 className="flex font-bold text-gray-600 space-x-2 text-2xl mb-5">
-            <GiCoffeeBeans className="relative transform translate-y-1 text-primary" />
-            <span>Login</span>
-          </h2>
-          <div className="flex flex-col space-y-3 w-full">
-            <label>Email</label>
-            <input
-              onChange
-              className="border border-gray-300 rounded-sm p-2 outline-none focus:ring-1 focus:ring-primary"
-              name="email"
-              type="email"
-              placeholder="Enter your email here"
-              onChange={(event) => handleChange(event, "email")}
-            ></input>
-            <label>Password</label>
-            <input
-              className="border  border-gray-300 rounded-sm p-2 outline-none focus:ring-1 focus:ring-primary"
-              name="password"
-              type="password"
-              placeholder="Enter your password here"
-              onChange={(event) => handleChange(event, "password")}
-            ></input>
+      {authStateChecked ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 md:h-96 border border-gray-300 rounded-2xl shadow-xl overflow-hidden">
+          <form className="w-full p-12 col-span-1 flex flex-col justify-center flex-shrink-0">
+            <h2 className="flex font-bold text-gray-600 space-x-2 text-2xl mb-5">
+              <GiCoffeeBeans className="relative transform translate-y-1 text-primary" />
+              <span>Login</span>
+            </h2>
+            <div className="flex flex-col space-y-3 w-full">
+              <label>Email</label>
+              <input
+                onChange
+                className="border border-gray-300 rounded-sm p-2 outline-none focus:ring-1 focus:ring-primary"
+                name="email"
+                type="email"
+                placeholder="Enter your email here"
+                onChange={(event) => handleChange(event, "email")}
+              ></input>
+              <label>Password</label>
+              <input
+                className="border  border-gray-300 rounded-sm p-2 outline-none focus:ring-1 focus:ring-primary"
+                name="password"
+                type="password"
+                placeholder="Enter your password here"
+                onChange={(event) => handleChange(event, "password")}
+              ></input>
+            </div>
+            <div className="flex space-x-3">
+              <button
+                className="default-btn"
+                type="submit"
+                onClick={(e) => submit(e)}
+                disabled={loading}
+              >
+                {loading ? <AnimatedLoadingIcon size="1.4em" /> : "Login"}
+              </button>
+              <Link
+                to="/register"
+                className="shadow-md disabled:opacity-50 border-2 border-primary text-primary px-4 py-2 rounded-full mt-4 hover:text-white transition hover:bg-primary flex-shrink-0"
+              >
+                Create an Account
+              </Link>
+            </div>
+          </form>
+          <div className="h-40 md:h-full md:w-full bg-login-img bg-cover bg-center col-span-1 order-first md:order-last flex-shrink">
+            <h1 className="text-4xl text-center"></h1>
           </div>
-          <div className="flex space-x-3">
-            <button
-              className="default-btn"
-              type="submit"
-              onClick={(e) => submit(e)}
-              disabled={loading}
-            >
-              {loading ? <AnimatedLoadingIcon size="1.4em" /> : "Login"}
-            </button>
-            <Link
-              to="/register"
-              className="shadow-md disabled:opacity-50 border-2 border-primary text-primary px-4 py-2 rounded-full mt-4 hover:text-white transition hover:bg-primary flex-shrink-0"
-            >
-              Create an Account
-            </Link>
-          </div>
-        </form>
-        <div className="h-40 md:h-full md:w-full bg-login-img bg-cover bg-center col-span-1 order-first md:order-last flex-shrink">
-          <h1 className="text-4xl text-center"></h1>
         </div>
-      </div>
+      ) : (
+        <AnimatedLoadingIcon size="5em" />
+      )}
     </div>
   );
 };

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -13,17 +13,17 @@ import DropDown from "./DropDown.js";
 import { toast } from "react-toastify";
 
 import NavSearch from "./NavSearch";
+import AuthRender from "./AuthRender";
 
 const Nav = () => {
   const history = useHistory();
+  const { logout, currentUser, authStateChecked } = useAuth();
   const [searchMode, setSearchMode] = useState(false);
   const [menuActive, setMenuActive] = useState({
     state: false,
     btnClass: "",
     menuClass: "-translate-y-full",
   });
-  const menu = useRef();
-  const { logout, currentUser } = useAuth();
 
   useEffect(() => {
     handleMenuButton();
@@ -127,7 +127,7 @@ const Nav = () => {
               </div>
 
               <div className="md:hidden flex space-x-4">
-                {!currentUser ? (
+                {authStateChecked && !currentUser ? (
                   <>
                     <Link
                       onClick={handleMenuButton}
@@ -188,7 +188,7 @@ const Nav = () => {
               <span className="bg-gray-800 w-full h-0.5 rounded-sm  transform transition-transform duration-300"></span>
             </div>
             <ul className="hidden md:flex md:space-x-2">
-              {!currentUser && (
+              {authStateChecked && !currentUser && (
                 <React.Fragment>
                   <li>
                     <Link
@@ -208,31 +208,30 @@ const Nav = () => {
                   </li>
                 </React.Fragment>
               )}
-              {currentUser && (
-                <>
-                  {/* <div className="w-12 h-12 rounded-full bg-gray-100"></div> */}
-                  <DropDown
-                    menuClass="bg-primary hover:bg-yellow-400 transition focus:ring-2 focus:ring-offset-2 focus:ring-primary transform active:scale-75"
-                    label={<SiCoffeescript className="text-white" />}
-                    items={[
-                      {
-                        icon: <BsFillPersonFill className="text-primary" />,
-                        label: "Profile",
-                        route: "/profile",
-                      },
-                      {
-                        icon: <GoSignOut className="text-primary" />,
-                        label: "Sign Out",
-                        route: "/logout",
-                        onClick: handleLogout,
-                      },
-                    ]}
-                  />
-                  {/* <li>
+
+              <AuthRender>
+                {/* <div className="w-12 h-12 rounded-full bg-gray-100"></div> */}
+                <DropDown
+                  menuClass="bg-primary hover:bg-yellow-400 transition focus:ring-2 focus:ring-offset-2 focus:ring-primary transform active:scale-75"
+                  label={<SiCoffeescript className="text-white" />}
+                  items={[
+                    {
+                      icon: <BsFillPersonFill className="text-primary" />,
+                      label: "Profile",
+                      route: "/profile",
+                    },
+                    {
+                      icon: <GoSignOut className="text-primary" />,
+                      label: "Sign Out",
+                      route: "/logout",
+                      onClick: handleLogout,
+                    },
+                  ]}
+                />
+                {/* <li>
                     <Link onClick={handleLogout}> Logout </Link>
                   </li> */}
-                </>
-              )}
+              </AuthRender>
             </ul>
           </div>
         </div>

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -10,7 +10,7 @@ const RegisterForm = () => {
     email: "",
     password: "",
   });
-  const { register, currentUser } = useAuth();
+  const { register, currentUser, authStateChecked } = useAuth();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [passwordStrength, setPasswordStrength] = useState({
@@ -54,61 +54,65 @@ const RegisterForm = () => {
   };
 
   return (
-    <div>
-      <h1 className="text-4xl text-yellow-500 text-center font-extrabold">
-        Register
-      </h1>
-      <p className="text-center p-4">
-        {currentUser && "Currently logged in: " + currentUser.email}
-      </p>
-      <form className="relative w-96 mx-auto p-12 border border-gray-300 rounded-md h-auto bg-white">
-        {error && (
-          <p className="text-center p-4 text-red-600 bg-red-200 w-72 rounded-lg  justify-self mb-4 text-sm">
-            {error}
+    <>
+      {authStateChecked && (
+        <div>
+          <h1 className="text-4xl text-yellow-500 text-center font-extrabold">
+            Register
+          </h1>
+          <p className="text-center p-4">
+            {currentUser && "Currently logged in: " + currentUser.email}
           </p>
-        )}
-        <div className="flex flex-col space-y-3">
-          <label>Email</label>
-          <input
-            className="border border-gray-300 rounded-sm p-2"
-            name="email"
-            type="email"
-            placeholder="Enter your email here"
-            onChange={(event) => handleChange(event, "email")}
-          ></input>
-          <label>Password</label>
-          <input
-            className="border border-gray-300 rounded-sm p-2"
-            name="password"
-            type="password"
-            placeholder="Enter your password here"
-            onChange={(event) => handleChange(event, "password")}
-          ></input>
-        </div>
-        <p className="absolute text-right p-4 text-green-600 rounded-lg justify-content text-sm right-8 w-44">
-          <p className="text-red-500">
-            {passwordStrength.length < 6 &&
-              passwordStrength.length > 0 &&
-              "Bad password"}
-          </p>
-          <p className="text-yellow-500">
-            {passwordStrength.length >= 6 &&
-              passwordStrength.length < 10 &&
-              "Good"}
-          </p>
-          {passwordStrength.length >= 10 && "Great"}
-        </p>
+          <form className="relative w-96 mx-auto p-12 border border-gray-300 rounded-md h-auto bg-white">
+            {error && (
+              <p className="text-center p-4 text-red-600 bg-red-200 w-72 rounded-lg  justify-self mb-4 text-sm">
+                {error}
+              </p>
+            )}
+            <div className="flex flex-col space-y-3">
+              <label>Email</label>
+              <input
+                className="border border-gray-300 rounded-sm p-2"
+                name="email"
+                type="email"
+                placeholder="Enter your email here"
+                onChange={(event) => handleChange(event, "email")}
+              ></input>
+              <label>Password</label>
+              <input
+                className="border border-gray-300 rounded-sm p-2"
+                name="password"
+                type="password"
+                placeholder="Enter your password here"
+                onChange={(event) => handleChange(event, "password")}
+              ></input>
+            </div>
+            <p className="absolute text-right p-4 text-green-600 rounded-lg justify-content text-sm right-8 w-44">
+              <p className="text-red-500">
+                {passwordStrength.length < 6 &&
+                  passwordStrength.length > 0 &&
+                  "Bad password"}
+              </p>
+              <p className="text-yellow-500">
+                {passwordStrength.length >= 6 &&
+                  passwordStrength.length < 10 &&
+                  "Good"}
+              </p>
+              {passwordStrength.length >= 10 && "Great"}
+            </p>
 
-        <button
-          className="default-btn"
-          type="submit"
-          onClick={(e) => submit(e)}
-          disabled={loading}
-        >
-          {loading ? <AnimatedLoadingIcon size="1.4em" /> : "Register"}
-        </button>
-      </form>
-    </div>
+            <button
+              className="default-btn"
+              type="submit"
+              onClick={(e) => submit(e)}
+              disabled={loading}
+            >
+              {loading ? <AnimatedLoadingIcon size="1.4em" /> : "Register"}
+            </button>
+          </form>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -9,6 +9,7 @@ export function useAuth() {
 
 export function AuthProvider({ children }) {
   const [currentUser, setCurrentUser] = useState();
+  const [authStateChecked, setAuthStateChecked] = useState(false);
 
   function register(email, password) {
     return auth.createUserWithEmailAndPassword(email, password);
@@ -25,6 +26,7 @@ export function AuthProvider({ children }) {
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((user) => {
       setCurrentUser(user);
+      setAuthStateChecked(true);
     });
     return unsubscribe;
   }, []);
@@ -34,6 +36,7 @@ export function AuthProvider({ children }) {
     register,
     login,
     logout,
+    authStateChecked,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
Fixed a bug where Login and Register Buttons render even when not authorized.

All I did was add a boolean to the auth context that defaults to false before the component mounts.
When it mounts(useEffect), I set the boolean to true.

I use that boolean for all useAuth() stuff and basically render stuff only after auth check.

The goal is to create a system surrounding this so it's easier to make conditional rendering for all auth stuff.

There's a bug right now where.. if you are logged in, and refresh a private route like (/profile, /review) you will always be redirected to the /login route. This is because I hard coded the check for not being authorized and immediately redirecting to /login. It doesn't take account for the new boolean that gets changed only after auth check. A possible fix is to use that boolean in the AuthContext, and only check if not authorized to redirect AFTER the auth check. Pretty easy.